### PR TITLE
Install Vagrant 1.9.7 by Default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,8 +12,7 @@
 #  The ensure value for the package resource, defaults to 'installed'.
 #
 # [*version*]
-#  The version of Vagrant to install, defaults to '1.7.4'.  If you are
-#  change this, you will have to modify the `source` parameter accordingly.
+#  The version of Vagrant to install, defaults to '1.9.7'.
 #
 # [*cache*]
 #  On Linux systems, location to store the downloaded Vagrant package,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,14 +4,14 @@
 #
 class vagrant::params {
   # Setting up properties for the package.
-  if $::architecture == 'amd64' {
+  if ($::architecture == 'amd64' or $::architecture == 'x86_64') {
     $arch = 'x86_64'
   } else {
     $arch = 'i686'
   }
 
   # The version of Vagrant to install.
-  $version = '1.7.4'
+  $version = hiera('vagrant::version', '1.7.4')
 
   # Where to cache Vagrant package downloads, if necessary.
   $cache = '/var/cache/vagrant'
@@ -19,7 +19,13 @@ class vagrant::params {
   case $::osfamily {
     'Darwin': {
       $package = "vagrant-${version}"
-      $package_basename = "vagrant_${version}.dmg"
+      if versioncmp($version, '1.9.2') > 0 {
+        # from version 1.9.3 upward, the .dmg includes the architecture
+        $package_basename = "vagrant_${version}_${arch}.dmg"
+      }
+      else {
+        $package_basename = "vagrant_${version}.dmg"
+      }
       $provider = 'pkgdmg'
       $download = false
     }
@@ -41,6 +47,7 @@ class vagrant::params {
   }
 
   # The download URL for Vagrant.
-  $base_url = 'https://dl.bintray.com/mitchellh/vagrant/'
-  $package_url = "${base_url}${package_basename}"
+  $base_url = hiera(
+      'vagrant::package_url', 'https://releases.hashicorp.com/vagrant/')
+  $package_url = "${base_url}${version}/${package_basename}"
 }


### PR DESCRIPTION
@jdavisp3

Updates the parameters of this package to support installing Vagrant 1.9.7.

 * Download Vagrant installer from its new home at HashiCorp.
 * Update filename style used for Mac OS X packages (they now include the architecture).
 * Look up variables that affect other parameters from hiera, so they can be overridden.

I'm a little less sure of the last item. Does this look like the correct approach? The issue this fixes is that setting `vagrant::version: 1.9.7` in hiera would not modify the package name defined in `params.pp`.