### PR TITLE
Set source as undef since default is not defined

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,7 +48,7 @@ class vagrant(
   $package_basename = $vagrant::params::package_basename,
   $package_url      = $vagrant::params::package_url,
   $provider         = $vagrant::params::provider,
-  $source           = $vagrant::params::source,
+  $source           = undef,
 ) inherits vagrant::params {
 
   # If we're downloading the package, then it's source will be from the local


### PR DESCRIPTION
Since `source` is not defined in `params.pp`, latest puppet prints the following warning:

```
Warning: Unknown variable: 'vagrant::params::source'. at /etc/puppetlabs/code/environments/new_vagrant/modules/vagrant/manifests/init.pp:51:23
```

This PR fixes the warning by setting the parameter as `undef`.