### PR TITLE
Release 0.9.22.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.22 (11/11/2019)
+
+IMPROVEMENTS:
+
+* Upgrade vagrant if different than configured version (Jakov Sosic).
+
 ## 0.9.21 (07/28/2019)
 
 IMPROVEMENTS:

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "counsyl-vagrant",
-  "version": "0.9.21",
+  "version": "0.9.22",
   "author": "Counsyl, Inc.",
   "summary": "Puppet module for installing and configuring Vagrant",
   "license": "Apache-2.0",


### PR DESCRIPTION
@jsosic Prepare to release 0.9.22.

## 0.9.22 (11/11/2019)

IMPROVEMENTS:

* Upgrade vagrant if different than configured version (Jakov Sosic).
